### PR TITLE
Correction de la REGEX de recherche de carte pour éviter les plantages

### DIFF
--- a/src/CardService.js
+++ b/src/CardService.js
@@ -15,7 +15,7 @@ const CardService = {
     const searchResultPage = await axios.get(url);
     const $ = cheerio.load(searchResultPage.data);
 
-    const REGEX = /^([^(]+)(?: \((\d)\))?$/;
+    const REGEX = /^([^(]+(?: \(\D+\))?)(?: \((\d)\))?$/;
 
     const cards = $("table.tableau")
       // C'est toujours le dernier tableau qui contient la recherche par titre


### PR DESCRIPTION
Afin de prendre en compte le cas d'un sous-titre entre parenthèses comme "Serment Indicible (Soif de Sang)".